### PR TITLE
Poplar2

### DIFF
--- a/python/tvm/runtime/ndarray.py
+++ b/python/tvm/runtime/ndarray.py
@@ -479,7 +479,7 @@ def webgpu(dev_id=0):
 
 
 def ipu(dev_id=0):
-    """Construct a IPU device
+    """Construct an IPU device.
 
     Parameters
     ----------

--- a/src/relay/backend/contrib/poplar/codegen.cc
+++ b/src/relay/backend/contrib/poplar/codegen.cc
@@ -15,7 +15,6 @@
 #include "../../utils.h"
 
 #include "../../../../runtime/contrib/poplar/fn_info.h"
-#include "../../../../runtime/contrib/poplar/common.h"
 
 namespace tvm {
 namespace relay {
@@ -264,8 +263,12 @@ public:
 
 runtime::Module PoplarCompiler(const ObjectRef& ref) {
   // XXX: We need some way for the user to configure this
-  // XXX: This allow to easy change from IPUModel to IPU real device by just modifying one line in poplar.cc:
-  poplar::Target t = tvm::runtime::contrib::IPUDeviceAPI::Global()->getTarget();
+  int num_ipu = 1;
+  char* tmp = getenv("TVM_POPLAR_NUM_IPU");
+  if (tmp != NULL)
+    num_ipu = std::atoi(tmp);
+
+  poplar::Target t = poplar::Target::createIPUTarget(num_ipu, "ipu1");
   poplar::Graph g(t);
   popops::addCodelets(g);
   PoplarCodeGen codegen;

--- a/src/relay/backend/contrib/poplar/codegen.cc
+++ b/src/relay/backend/contrib/poplar/codegen.cc
@@ -4,6 +4,7 @@
 #include <poplar/Type.hpp>
 #include <poplar/VariableMappingMethod.hpp>
 #include <poplar/Engine.hpp>
+#include <poplar/IPUModel.hpp>
 #include <popops/ElementWise.hpp>
 #include <popops/codelets.hpp>
 
@@ -264,11 +265,22 @@ public:
 runtime::Module PoplarCompiler(const ObjectRef& ref) {
   // XXX: We need some way for the user to configure this
   int num_ipu = 1;
+  bool use_model = false;
   char* tmp = getenv("TVM_POPLAR_NUM_IPU");
   if (tmp != NULL)
     num_ipu = std::atoi(tmp);
 
-  poplar::Target t = poplar::Target::createIPUTarget(num_ipu, "ipu1");
+  tmp = getenv("TVM_POPLAR_USE_MODEL");
+  if (tmp != NULL)
+    use_model = bool(std::atoi(tmp));
+
+  poplar::Target t;
+  if (use_model) {
+    poplar::IPUModel m;
+    t = m.createDevice().getTarget();
+  } else {
+    t = poplar::Target::createIPUTarget(num_ipu, "ipu1");
+  }
   poplar::Graph g(t);
   popops::addCodelets(g);
   PoplarCodeGen codegen;

--- a/src/runtime/contrib/poplar/common.h
+++ b/src/runtime/contrib/poplar/common.h
@@ -51,7 +51,6 @@ public:
     // XXX: Hard-code this for now, don't use from multiple threads
     IPUThreadEntry* t = GetThreadEntry();
     bool use_model = false;
-    int num_dev = 1;
     char* tmp = getenv("TVM_POPLAR_USE_MODEL");
 
     if (tmp != NULL)

--- a/src/runtime/contrib/poplar/common.h
+++ b/src/runtime/contrib/poplar/common.h
@@ -39,10 +39,6 @@ public:
     }
   }
 
-  poplar::Device& get_device() {
-    return device_;
-  }
-
  private:
   bool valid_;
   poplar::Device device_;
@@ -54,13 +50,19 @@ public:
   IPUDeviceAPI() : m_(poplar::DeviceManager::createDeviceManager()) {
     // XXX: Hard-code this for now, don't use from multiple threads
     IPUThreadEntry* t = GetThreadEntry();
-    t->set_device(m_.getDevice(0));
-    // poplar::IPUModel ipuModel;
-    // t->set_device(ipuModel.createDevice());
-  }
+    bool use_model = false;
+    int num_dev = 1;
+    char* tmp = getenv("TVM_POPLAR_USE_MODEL");
 
-  poplar::Target getTarget() {
-    return GetThreadEntry()->get_device().getTarget();
+    if (tmp != NULL)
+      use_model = bool(atoi(tmp));
+
+    if (!use_model) {
+      t->set_device(m_.getDevice(0));
+    } else {
+      poplar::IPUModel m;
+      t->set_device(m.createDevice());
+    }
   }
 
   void SetDevice(TVMContext ctx) final {

--- a/tests/python/relay/test_ipu.py
+++ b/tests/python/relay/test_ipu.py
@@ -13,6 +13,11 @@ import numpy as np
 
 def check_result(mod, map_inputs, out_shape, result, tol=1e-5, target="llvm",
                  ctx=tvm.cpu()):
+    import os
+
+    # Don't use anything other than '1' for the num, for now.
+    os.environ['TVM_POPLAR_NUM_IPU'] = '1'
+    os.environ['TVM_POPLAR_USE_MODEL'] = '0'
 
     def check_vm_result():
         with tvm.transform.PassContext(opt_level=3,

--- a/tests/python/relay/test_ipu.py
+++ b/tests/python/relay/test_ipu.py
@@ -13,11 +13,6 @@ import numpy as np
 
 def check_result(mod, map_inputs, out_shape, result, tol=1e-5, target="llvm",
                  ctx=tvm.cpu()):
-    import os
-
-    # Don't use anything other than '1' for the num, for now.
-    os.environ['TVM_POPLAR_NUM_IPU'] = '1'
-    os.environ['TVM_POPLAR_USE_MODEL'] = '0'
 
     def check_vm_result():
         with tvm.transform.PassContext(opt_level=3,


### PR DESCRIPTION
This allow setting TVM_POPLAR_USE_MODEL={0,1} to switch between model and real device at runtime.

0 = real device
1 = model device

There are some references to TVM_POPLAR_NUM_IPU too but don't use it, it will probably break something.

